### PR TITLE
Feature/improved heartbeats

### DIFF
--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -290,7 +290,7 @@ void FDriftBase::TickHeartbeat(float deltaTime)
     request->OnResponse.BindLambda([this](ResponseContext& context, JsonDocument& doc)
     {
         FDriftHeartBeatResponse response;
-        if (JsonUtils::ParseResponse(context.response, response))
+        if (JsonUtils::ParseResponseNoLog(context.response, response))
         {
             const auto heartbeatRoundTrip = FTimespan::FromSeconds(context.request.Get()->GetElapsedTime());
             heartbeatDueInSeconds_ = response.next_heartbeat_seconds;

--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -373,6 +373,9 @@ private:
     const int32 instanceIndex_;
 
     float heartbeatDueInSeconds_{ FLT_MAX };
+	float heartbeatRetryDelay_{ 1.0f };
+	int32 heartbeatRetryAttempt_{ 0 };
+	float heartbeatRetryDelayCap_{ 10.0f };
     FDateTime heartbeatTimeout_{ FDateTime::MinValue() };
 
     DriftSessionState state_;
@@ -386,7 +389,7 @@ private:
     FClientRegistrationResponse driftClient;
     FDriftPlayerResponse myPlayer;
 
-    FString hearbeatUrl;
+    FString heartbeatUrl;
 
     TUniquePtr<FDriftCounterManager> playerCounterManager;
     TMap<int32, TUniquePtr<FDriftCounterManager>> serverCounterManagers;

--- a/JsonArchive/Public/JsonUtils.h
+++ b/JsonArchive/Public/JsonUtils.h
@@ -28,7 +28,7 @@ public:
 	template<class T>
 	static bool ParseResponse(FHttpResponsePtr response, T& parsed)
 	{
-		bool success = ParseResponseNoLog(response, parsed);
+		const bool success = ParseResponseNoLog(response, parsed);
 		
 		if (!success)
 		{


### PR DESCRIPTION
Fixing the heartbeat logic, which has been causing primarily battle servers to get disconnected. Servers still need to implement actual handling of the timeout, but they won't timeout without retrying.

- Unify the client and server response parser, since the back-end now returns the same data for both. But fall back to the old format, since the server might not have been updated yet.
- Ensure a failure to send a request bypasses all attempts at processing the response.
- If heartbeats fail, retry with an exponentially increasing, random, back-off, until succeeding or the actual timeout happens.
- The reason for the random back-off, is that you don't want a lot of servers to end up in a cycle of retrying at the same time.
- Clarified some calculations by adding intermediate variables.
- Fixed spelling errors.