### PR TITLE
Server registration retrying on backend failure

### DIFF
--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -2950,11 +2950,7 @@ void FDriftBase::InitServerRootInfo()
     	Reset();
     });
 
-	Request->SetRetries(3);
-	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
-	{
-		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
-	}));
+	Request->AddRetryHandlingOnServerError();
 
     Request->Dispatch();
 }
@@ -3044,12 +3040,7 @@ void FDriftBase::InitServerAuthentication()
     	Reset();
     });
 
-	Request->SetRetries(3);
-	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
-	{
-		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
-	}));
-
+	Request->AddRetryHandlingOnServerError();
 
     Request->Dispatch();
 }
@@ -3117,11 +3108,7 @@ void FDriftBase::InitServerRegistration()
     	Reset();
     });
 
-	Request->SetRetries(3);
-	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
-	{
-		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
-	}));
+	Request->AddRetryHandlingOnServerError();
 
     Request->Dispatch();
 }
@@ -3148,11 +3135,7 @@ void FDriftBase::InitServerInfo()
     	Reset();
     });
 
-	Request->SetRetries(3);
-	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
-	{
-		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
-	}));
+	Request->AddRetryHandlingOnServerError();
 
     Request->Dispatch();
 }
@@ -3181,11 +3164,7 @@ void FDriftBase::FinalizeRegisteringServer()
 		Reset();
 	});
 
-	Request->SetRetries(3);
-	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
-	{
-		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
-	}));
+	Request->AddRetryHandlingOnServerError();
 
 	Request->Dispatch();
 }

--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -2944,22 +2944,18 @@ void FDriftBase::InitServerRootInfo()
     });
     Request->OnError.BindLambda([this](ResponseContext& Context)
     {
-        Context.errorHandled = true;
-
     	DRIFT_LOG(Base, Error, TEXT("Failed to fetch Drift endpoints"));
 
-    	if (Context.response.IsValid() && Context.response->GetResponseCode() >= 500)
-    	{
-    		DRIFT_LOG(Base, Log, TEXT("Retrying fetching Drift endpoints"));
-
-    		// Retry if server error (5XX HTTP status code)
-    		InitServerRootInfo();
-    	}
-    	else
-    	{
-    		Reset();
-    	}
+        Context.errorHandled = true;
+    	Reset();
     });
+
+	Request->SetRetries(3);
+	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
+	{
+		return Response.IsValid() && Response->GetResponseCode() >= 500;
+	}));
+
     Request->Dispatch();
 }
 
@@ -3042,22 +3038,19 @@ void FDriftBase::InitServerAuthentication()
     });
     Request->OnError.BindLambda([this](ResponseContext& Context)
     {
+    	DRIFT_LOG(Base, Error, TEXT("Failed to authenticate server"));
+
     	Context.errorHandled = true;
-
-		DRIFT_LOG(Base, Error, TEXT("Failed to authenticate server"));
-
-		if (Context.response.IsValid() && Context.response->GetResponseCode() >= 500)
-		{
-			DRIFT_LOG(Base, Log, TEXT("Retrying authenticating server"));
-
-			// Retry if server error (5XX HTTP status code)
-			InitServerAuthentication();
-		}
-		else
-		{
-			Reset();
-		}
+    	Reset();
     });
+
+	Request->SetRetries(3);
+	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
+	{
+		return Response.IsValid() && Response->GetResponseCode() >= 500;
+	}));
+
+
     Request->Dispatch();
 }
 
@@ -3118,22 +3111,18 @@ void FDriftBase::InitServerRegistration()
     });
     Request->OnError.BindLambda([this](ResponseContext& Context)
     {
+    	DRIFT_LOG(Base, Error, TEXT("Failed to register server"));
+
     	Context.errorHandled = true;
-
-		DRIFT_LOG(Base, Error, TEXT("Failed to register server"));
-
-		if (Context.response.IsValid() && Context.response->GetResponseCode() >= 500)
-		{
-			DRIFT_LOG(Base, Log, TEXT("Retrying registering server"));
-
-			// Retry if server error (5XX HTTP status code)
-			InitServerRegistration();
-		}
-		else
-		{
-			Reset();
-		}
+    	Reset();
     });
+
+	Request->SetRetries(3);
+	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
+	{
+		return Response.IsValid() && Response->GetResponseCode() >= 500;
+	}));
+
     Request->Dispatch();
 }
 
@@ -3153,22 +3142,18 @@ void FDriftBase::InitServerInfo()
     });
     Request->OnError.BindLambda([this](ResponseContext& Context)
     {
+    	DRIFT_LOG(Base, Error, TEXT("Failed to initialize server info"));
+
     	Context.errorHandled = true;
-
-		DRIFT_LOG(Base, Error, TEXT("Failed to initialize server info"));
-
-		if (Context.response.IsValid() && Context.response->GetResponseCode() >= 500)
-		{
-			DRIFT_LOG(Base, Log, TEXT("Retrying initializing server info"));
-
-			// Retry if server error (5XX HTTP status code)
-			InitServerInfo();
-		}
-		else
-		{
-			Reset();
-		}
+    	Reset();
     });
+
+	Request->SetRetries(3);
+	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
+	{
+		return Response.IsValid() && Response->GetResponseCode() >= 500;
+	}));
+
     Request->Dispatch();
 }
 
@@ -3190,22 +3175,18 @@ void FDriftBase::FinalizeRegisteringServer()
 	});
 	Request->OnError.BindLambda([this](ResponseContext& Context)
 	{
-		Context.errorHandled = true;
-
 		DRIFT_LOG(Base, Error, TEXT("Failed to finalize registering server"));
 
-		if (Context.response.IsValid() && Context.response->GetResponseCode() >= 500)
-		{
-			DRIFT_LOG(Base, Log, TEXT("Retrying finalizing register server"));
-
-			// Retry if server error (5XX HTTP status code)
-			FinalizeRegisteringServer();
-		}
-		else
-		{
-			Reset();
-		}
+		Context.errorHandled = true;
+		Reset();
 	});
+
+	Request->SetRetries(3);
+	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
+	{
+		return Response.IsValid() && Response->GetResponseCode() >= 500;
+	}));
+
 	Request->Dispatch();
 }
 

--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -2953,7 +2953,7 @@ void FDriftBase::InitServerRootInfo()
 	Request->SetRetries(3);
 	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
 	{
-		return Response.IsValid() && Response->GetResponseCode() >= 500;
+		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
 	}));
 
     Request->Dispatch();
@@ -3047,7 +3047,7 @@ void FDriftBase::InitServerAuthentication()
 	Request->SetRetries(3);
 	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
 	{
-		return Response.IsValid() && Response->GetResponseCode() >= 500;
+		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
 	}));
 
 
@@ -3120,7 +3120,7 @@ void FDriftBase::InitServerRegistration()
 	Request->SetRetries(3);
 	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
 	{
-		return Response.IsValid() && Response->GetResponseCode() >= 500;
+		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
 	}));
 
     Request->Dispatch();
@@ -3151,7 +3151,7 @@ void FDriftBase::InitServerInfo()
 	Request->SetRetries(3);
 	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
 	{
-		return Response.IsValid() && Response->GetResponseCode() >= 500;
+		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
 	}));
 
     Request->Dispatch();
@@ -3184,7 +3184,7 @@ void FDriftBase::FinalizeRegisteringServer()
 	Request->SetRetries(3);
 	Request->SetShouldRetryDelegate(FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
 	{
-		return Response.IsValid() && Response->GetResponseCode() >= 500;
+		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
 	}));
 
 	Request->Dispatch();

--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -232,7 +232,8 @@ private:
     void InitServerRootInfo();
     void InitServerAuthentication();
     void InitServerRegistration();
-    void InitServerInfo(const FString& serverUrl);
+	void InitServerInfo();
+	void FinalizeRegisteringServer();
 
     /**
      * Disconnect the player if connected, flush counters and events, and reset the internal state.

--- a/DriftHttp/Private/HttpRequest.cpp
+++ b/DriftHttp/Private/HttpRequest.cpp
@@ -470,6 +470,15 @@ FString HttpRequest::GetRequestURL() const
 }
 
 
+void HttpRequest::AddRetryHandlingOnServerError()
+{
+	MaxRetries_ = 3;
+	shouldRetryDelegate_ = FShouldRetryDelegate::CreateLambda([](FHttpRequestPtr Request, FHttpResponsePtr Response)
+	{
+		return Response.IsValid() && Response->GetResponseCode() >= static_cast<int32>(HttpStatusCodes::FirstServerError);
+	});
+}
+
 FString HttpRequest::GetAsDebugString(bool detailed) const
 {
 #if !UE_BUILD_SHIPPING

--- a/DriftHttp/Public/HttpRequest.h
+++ b/DriftHttp/Public/HttpRequest.h
@@ -150,6 +150,8 @@ public:
 
 	void SetCache(TSharedPtr<IHttpCache> cache);
 
+	void SetShouldRetryDelegate(FShouldRetryDelegate Delegate) { shouldRetryDelegate_ = Delegate; }
+
 	void SetExpectJsonResponse(bool expectJsonResponse) { expectJsonResponse_ = expectJsonResponse; }
 
 	FString GetAsDebugString(bool detailed = false) const;

--- a/DriftHttp/Public/HttpRequest.h
+++ b/DriftHttp/Public/HttpRequest.h
@@ -154,6 +154,8 @@ public:
 
 	void SetExpectJsonResponse(bool expectJsonResponse) { expectJsonResponse_ = expectJsonResponse; }
 
+	void AddRetryHandlingOnServerError();
+
 	FString GetAsDebugString(bool detailed = false) const;
 
 	FString GetRequestURL() const;


### PR DESCRIPTION
Added basic retrying if the response indicates that something went wrong on the backend and nothing was wrong with the request.

This is done by checking if the response code is above or equal to 500.

I also renamed some local variables to PascalCase to conform with UE4 style guidelines