### PR TITLE
Server player gamestates

### DIFF
--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -105,7 +105,9 @@ public:
     void LoadPlayerStats() override;
 
     void LoadPlayerGameState(const FString& name, const FDriftGameStateLoadedDelegate& delegate) override;
+	void LoadPlayerGameState(int32 playerId, const FString& name, const FDriftGameStateLoadedDelegate& delegate) override;
     void SavePlayerGameState(const FString& name, const FString& gameState, const FDriftGameStateSavedDelegate& delegate) override;
+	void SavePlayerGameState(int32 playerId, const FString& name, const FString& gameState, const FDriftGameStateSavedDelegate& delegate) override;
 
     void GetLeaderboard(const FString& counterName, const TSharedRef<FDriftLeaderboard>& leaderboard, const FDriftLeaderboardLoadedDelegate& delegate) override;
     void GetFriendsLeaderboard(const FString& counterName, const TSharedRef<FDriftLeaderboard>& leaderboard, const FDriftLeaderboardLoadedDelegate& delegate) override;
@@ -296,7 +298,9 @@ private:
     void GetLeaderboardImpl(const FString& counterName, const TWeakPtr<FDriftLeaderboard>& leaderboard, const FString& playerGroup, const FDriftLeaderboardLoadedDelegate& delegate);
 
     void LoadPlayerGameStateImpl(const FString& name, const FDriftGameStateLoadedDelegate& delegate);
-    void SavePlayerGameStateImpl(const FString& name, const FString& state, const FDriftGameStateSavedDelegate& delegate);
+	void InternalLoadPlayerGameState(const FString& name, const FString& url, const FDriftGameStateLoadedDelegate& delegate);
+	void SavePlayerGameStateImpl(const FString& name, const FString& state, const FDriftGameStateSavedDelegate& delegate);
+	void InternalSavePlayerGameState(const FString& name, const FString& state, const FString& url, const FDriftGameStateSavedDelegate& delegate);
 
     void LoadPlayerGameStateInfos(TFunction<void(bool)> next);
 

--- a/Drift/Private/DriftSchemas.cpp
+++ b/Drift/Private/DriftSchemas.cpp
@@ -41,6 +41,7 @@ bool FDriftEndpointsResponse::Serialize(SerializationContext& context)
 		&& SERIALIZE_PROPERTY(context, match_placements)
 		&& SERIALIZE_PROPERTY(context, template_lobby_member)
 		&& SERIALIZE_PROPERTY(context, template_lobby_members)
+		&& SERIALIZE_PROPERTY(context, template_player_gamestate)
 
 		// Optional
 		&& SERIALIZE_PROPERTY(context, my_flexmatch)

--- a/Drift/Private/DriftSchemas.h
+++ b/Drift/Private/DriftSchemas.h
@@ -52,6 +52,7 @@ struct FDriftEndpointsResponse
 	// Templates
 	FString template_lobby_member;
 	FString template_lobby_members;
+	FString template_player_gamestate;
 
 	// Added after authentication
 	FString my_flexmatch;

--- a/Drift/Public/DriftAPI.h
+++ b/Drift/Public/DriftAPI.h
@@ -689,10 +689,22 @@ public:
     virtual void LoadPlayerGameState(const FString& name, const FDriftGameStateLoadedDelegate& delegate) = 0;
 
     /**
+     * Loads the player's named game state.
+     * Fires delegate when finished.
+     */
+    virtual void LoadPlayerGameState(int32 playerId, const FString& name, const FDriftGameStateLoadedDelegate& delegate) = 0;
+
+    /**
      * Saves the authenticated player's named game state.
      * Fires delegate when finished.
      */
     virtual void SavePlayerGameState(const FString& name, const FString& gameState, const FDriftGameStateSavedDelegate& delegate) = 0;
+
+    /**
+     * Saves the player's named game state.
+     * Fires delegate when finished.
+     */
+    virtual void SavePlayerGameState(int32 playerId, const FString& name, const FString& gameState, const FDriftGameStateSavedDelegate& delegate) = 0;
 
     /**
      * Get the global top leaderboard for counterName. Requires an authenticated player.


### PR DESCRIPTION
Allow the UE4 server to load and save player game states

Currently this would also work for clients, but ACL for the player gamestates is another task.