### PR TITLE
Drift events optimizations

### DIFF
--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -160,7 +160,7 @@ void FDriftBase::CreatePlayerCounterManager()
 
 void FDriftBase::CreateEventManager()
 {
-    eventManager = MakeUnique<FDriftEventManager>();
+    eventManager = MakeShared<FDriftEventManager>();
 }
 
 

--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -410,7 +410,7 @@ private:
     TUniquePtr<FDriftCounterManager> playerCounterManager;
     TMap<int32, TUniquePtr<FDriftCounterManager>> serverCounterManagers;
 
-    TUniquePtr<FDriftEventManager> eventManager;
+    TSharedPtr<FDriftEventManager> eventManager;
 
     TSharedPtr<FDriftMessageQueue> messageQueue;
 

--- a/Drift/Private/DriftEventManager.cpp
+++ b/Drift/Private/DriftEventManager.cpp
@@ -155,7 +155,8 @@ void FDriftEventManager::FlushEvents()
                 {
                     Request->SetPayload(Payload);
                 }
-                
+
+                Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
                 Request->Dispatch();
             });
         });

--- a/Drift/Private/DriftEventManager.h
+++ b/Drift/Private/DriftEventManager.h
@@ -13,7 +13,7 @@
 DECLARE_LOG_CATEGORY_EXTERN(LogDriftEvent, Log, All);
 DECLARE_STATS_GROUP(TEXT("Drift Event Manager"), STATGROUP_DriftEventManager, STATCAT_Advanced);
 
-class FDriftEventManager : public FTickableGameObject
+class FDriftEventManager : public FTickableGameObject, public TSharedFromThis<FDriftEventManager>
 {
 public:
     FDriftEventManager();

--- a/Drift/Private/DriftEventManager.h
+++ b/Drift/Private/DriftEventManager.h
@@ -11,7 +11,7 @@
 
 
 DECLARE_LOG_CATEGORY_EXTERN(LogDriftEvent, Log, All);
-
+DECLARE_STATS_GROUP(TEXT("Drift Event Manager"), STATGROUP_DriftEventManager, STATCAT_Advanced);
 
 class FDriftEventManager : public FTickableGameObject
 {

--- a/DriftHttp/Private/HttpRequest.cpp
+++ b/DriftHttp/Private/HttpRequest.cpp
@@ -37,6 +37,11 @@ HttpRequest::HttpRequest()
 }
 
 
+void HttpRequest::SetContent(const TArray<uint8>& ContentPayload)
+{
+	wrappedRequest_->SetContent(ContentPayload);
+}
+
 void HttpRequest::SetCache(TSharedPtr<IHttpCache> cache)
 {
 	cache_ = cache;

--- a/DriftHttp/Public/HttpRequest.h
+++ b/DriftHttp/Public/HttpRequest.h
@@ -151,11 +151,16 @@ public:
 
 	void SetContentType(const FString& contentType) { contentType_ = contentType; }
 
+	void SetContent(const TArray<uint8>& ContentPayload);
+
 	void SetCache(TSharedPtr<IHttpCache> cache);
 
 	void SetShouldRetryDelegate(FShouldRetryDelegate Delegate) { shouldRetryDelegate_ = Delegate; }
 
 	void SetExpectJsonResponse(bool expectJsonResponse) { expectJsonResponse_ = expectJsonResponse; }
+
+	/** Used by the request manager to set the payload */
+	void SetPayload(const FString& content);
 
 	FString GetAsDebugString(bool detailed = false) const;
 
@@ -190,9 +195,6 @@ private:
 
 protected:
 	friend class RequestManager;
-
-	/** Used by the request manager to set the payload */
-	void SetPayload(const FString& content);
 
 	/** Retry this request */
 	void Retry();


### PR DESCRIPTION
When there are a lot of events (> 100), the JSON to string processing can take 10-50ms on the GameThread.

2 optimizations are included in this PR

1. Limit the maximum number of pending events to 20 (about 0.5-1ms of JSON to string processing with the tested events)
2. Do the JSON to string processing not on the GameThread via AsyncTask

I also added some scope cycle counters for better profiling and verbose logs for debugging.