### PR TITLE
Add gzip compression to http payloads above a certain size

### DIFF
--- a/DriftHttp/Public/HttpRequest.h
+++ b/DriftHttp/Public/HttpRequest.h
@@ -159,7 +159,6 @@ public:
 
 	void SetExpectJsonResponse(bool expectJsonResponse) { expectJsonResponse_ = expectJsonResponse; }
 
-	/** Used by the request manager to set the payload */
 	void SetPayload(const FString& content);
 
 	FString GetAsDebugString(bool detailed = false) const;


### PR DESCRIPTION
Slightly modified version of the Sentry module gzip code to automatically compress payloads that are above a size threshold.