### PR TITLE
Use ICMP pinging instead of HTTP GET requests when measuring latency

### DIFF
--- a/Drift/Drift.Build.cs
+++ b/Drift/Drift.Build.cs
@@ -71,6 +71,7 @@ public class Drift : ModuleRules
                 "OnlineSubsystemUtils",
                 "DriftHttp",
                 "ErrorReporter",
+                "Icmp",
             }
             );
         

--- a/Drift/Private/DriftFlexmatch.cpp
+++ b/Drift/Private/DriftFlexmatch.cpp
@@ -68,8 +68,8 @@ void FDriftFlexmatch::MeasureLatencies()
 	for(auto Region: PingRegions)
 	{
 		static float PingTimeout = 2.0f;
-		const auto RegionUrl = FString::Format(*PingUrlTemplate, {Region});
-		FIcmp::IcmpEcho(RegionUrl, PingTimeout, FIcmpEchoResultDelegate::CreateLambda([WeakSelf = TWeakPtr<FDriftFlexmatch>(this->AsShared()), Region, LatenciesByRegion, RegionUrl](const FIcmpEchoResult Result)
+		const auto RegionHostname = FString::Format(*PingHostnameTemplate, {Region});
+		FIcmp::IcmpEcho(RegionHostname, PingTimeout, FIcmpEchoResultDelegate::CreateLambda([WeakSelf = TWeakPtr<FDriftFlexmatch>(this->AsShared()), Region, LatenciesByRegion, RegionHostname](const FIcmpEchoResult Result)
 		{
 			// Default to -1 if we fail to ping, success case will override this
 			LatenciesByRegion->Add(Region, -1);
@@ -80,7 +80,7 @@ void FDriftFlexmatch::MeasureLatencies()
 				{
 					const auto ResponseTime = static_cast<int>(Result.Time * 1000);
 
-					UE_LOG(LogDriftMatchmaking, Verbose, TEXT("FDriftFlexmatch::MeasureLatencies - Success - Hostname: '%s', Host address: '%s', Reply address: '%s', Time: '%d' ms"), *RegionUrl, *Result.ResolvedAddress, *Result.ReplyFrom, ResponseTime);
+					UE_LOG(LogDriftMatchmaking, Verbose, TEXT("FDriftFlexmatch::MeasureLatencies - Success - Hostname: '%s', Host address: '%s', Reply address: '%s', Time: '%d' ms"), *RegionHostname, *Result.ResolvedAddress, *Result.ReplyFrom, ResponseTime);
 
 					LatenciesByRegion->Add(Region, ResponseTime);
 
@@ -115,7 +115,7 @@ void FDriftFlexmatch::MeasureLatencies()
 
 				case EIcmpResponseStatus::Unresolvable:
 				{
-					UE_LOG(LogDriftMatchmaking, Error, TEXT("FDriftFlexmatch::MeasureLatencies - Unresolvable - Failed to resolve the target address '%s' to a valid IP address"), *RegionUrl);
+					UE_LOG(LogDriftMatchmaking, Error, TEXT("FDriftFlexmatch::MeasureLatencies - Unresolvable - Failed to resolve the target address '%s' to a valid IP address"), *RegionHostname);
 					break;
 				}
 

--- a/Drift/Private/DriftFlexmatch.h
+++ b/Drift/Private/DriftFlexmatch.h
@@ -91,7 +91,7 @@ private:
 	float TimeToPing = 0.0;
 	FLatencyMap AverageLatencyMap;
 	// TODO: Fetch valid region->pingServer mapping from backend.
-	const FString PingUrlTemplate = TEXT("gamelift.{0}.amazonaws.com");
+	const FString PingHostnameTemplate = TEXT("gamelift.{0}.amazonaws.com");
 	const TArray<FString> PingRegions{"eu-west-1"};
 
 	// Current state

--- a/Drift/Private/DriftFlexmatch.h
+++ b/Drift/Private/DriftFlexmatch.h
@@ -91,7 +91,7 @@ private:
 	float TimeToPing = 0.0;
 	FLatencyMap AverageLatencyMap;
 	// TODO: Fetch valid region->pingServer mapping from backend.
-	const FString PingUrlTemplate = TEXT("https://gamelift.{0}.amazonaws.com");
+	const FString PingUrlTemplate = TEXT("gamelift.{0}.amazonaws.com");
 	const TArray<FString> PingRegions{"eu-west-1"};
 
 	// Current state


### PR DESCRIPTION
HTTP requests add a lot of overhead and use TCP which adds some more overhead to the response time.

ICMP has a lot less overhead and is a better metric for a latency reference when matchmaking since UE4 servers use UDP.