### PR TITLE
Fix events not flushing when disconnecting

### DIFF
--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -412,7 +412,7 @@ void FDriftBase::FlushEvents()
 {
     check(eventManager);
 
-    eventManager->FlushEvents();
+    eventManager->FlushEvents(true);
 }
 
 

--- a/Drift/Private/DriftEventManager.h
+++ b/Drift/Private/DriftEventManager.h
@@ -33,7 +33,7 @@ public:
 
     void LoadCounters();
 
-    void FlushEvents();
+    void FlushEvents(bool bSynchronous = false);
 
     void SetRequestManager(TSharedPtr<JsonRequestManager> newRequestManager);
     void SetEventsUrl(const FString& newEventsUrl);
@@ -41,6 +41,12 @@ public:
 private:
     void InitDefaultTags();
     void AddTags(const TUniquePtr<IDriftEvent>& event);
+
+    void FlushEventsInternal();
+    void FlushEventsInternalAsync();
+
+    static void ProcessEvents(const TArray<TUniquePtr<IDriftEvent>>& Events, FString& Payload, TArray<uint8>& Compressed, bool& bUseCompressed);
+    static void ProcessRequest(const TSharedPtr<JsonRequestManager> RequestManager, const FString& URL, const FString& Payload, const TArray<uint8>& Compressed, bool bUseCompressed);
 
 private:
     TWeakPtr<JsonRequestManager> requestManager;


### PR DESCRIPTION
After the asynchronous flushing of events, the disconnection/shutdown event flush broke due to the request manager becoming invalid when in a background thread processing the events.

This PR adds a path for synchronous flushing accessed via bool parameter.
The parameter is only used by the `FlushEvents` call in `DriftAPI`/`DriftBase` since that is an explicit "Flush events right now".