### PR TITLE
Integrate `client_config` endpoint from drift-base into the client

### DIFF
--- a/Drift/Drift.Build.cs
+++ b/Drift/Drift.Build.cs
@@ -51,6 +51,7 @@ public class Drift : ModuleRules
                 "CoreUObject",
                 "Json",
                 "JsonArchive",
+                "JsonUtilities"
                 // ... add other public dependencies that you statically link with here ...
             }
             );

--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -2460,7 +2460,7 @@ void FDriftBase::InitDriftClientConfigs()
 
         auto ConfigJSON = doc.GetInternalValue()->AsObject();
 
-        if(!FJsonObjectConverter::JsonObjectToUStruct(ConfigJSON.ToSharedRef(), FDriftClientConfigListResponse::StaticStruct(), &ConfigList))
+        if (!FJsonObjectConverter::JsonObjectToUStruct(ConfigJSON.ToSharedRef(), FDriftClientConfigListResponse::StaticStruct(), &ConfigList))
         {
             FString Error;
             context.errorHandled = GetResponseError(context, Error);
@@ -2483,7 +2483,7 @@ void FDriftBase::InitDriftClientConfigs()
 FString FDriftBase::GetDriftClientConfigValue(const FString& ConfigKey)
 {
     FString* ValuePtr = DriftClientConfig.Find(ConfigKey);
-    if(!ValuePtr)
+    if (!ValuePtr)
     {
         DRIFT_LOG(Base, Warning, TEXT("Could not find client config value for key %s, returning empty string"), *ConfigKey);
         return TEXT("");

--- a/Drift/Private/DriftBase.cpp
+++ b/Drift/Private/DriftBase.cpp
@@ -2460,7 +2460,7 @@ void FDriftBase::InitDriftClientConfigs()
         if (!JsonArchive::LoadObject(doc, ConfigList))
         {
             FString Error;
-            context.error = TEXT("Failed to parse client config response");
+            context.errorHandled = GetResponseError(context, Error);
             DRIFT_LOG(Base, Error, TEXT("Failed to parse client configs from drift-base. Error: %s"), *Error);
             return;
         }
@@ -2489,6 +2489,8 @@ FString FDriftBase::GetDriftClientConfigValue(const FString& ConfigKey)
             return Entry.Value;
         }
     }
+
+    DRIFT_LOG(Base, Warning, TEXT("Could not find client config value for key %s, returning empty string", *ConfigKey));
 
     return TEXT("");
 }

--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -138,6 +138,8 @@ public:
     void FlushCounters() override;
     void FlushEvents() override;
 
+    FString GetDriftClientConfigValue(const FString& ConfigKey) override;
+
     void Shutdown() override;
 
     const TMap<FString, FDateTime>& GetDeprecations() override;
@@ -219,6 +221,7 @@ public:
 
 private:
     void ConfigureSettingsSection(const FString& config);
+    void InitDriftClientConfigs();
 
     void GetRootEndpoints(TFunction<void()> onSuccess);
     void InitAuthentication(const FAuthenticationSettings& AuthenticationSettings);
@@ -497,6 +500,8 @@ private:
 	FString serverBearerToken_;
 
 	TMap<int32, int32> PlayerIdToTeamId;
+
+    TArray<TPair<FString,FString>> DriftClientConfig;
 };
 
 

--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -501,7 +501,7 @@ private:
 
 	TMap<int32, int32> PlayerIdToTeamId;
 
-    TMap<FString,FString> DriftClientConfig;
+    TMap<FString, FString> DriftClientConfig;
 };
 
 

--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -501,7 +501,7 @@ private:
 
 	TMap<int32, int32> PlayerIdToTeamId;
 
-    TArray<TPair<FString,FString>> DriftClientConfig;
+    TMap<FString,FString> DriftClientConfig;
 };
 
 

--- a/Drift/Private/DriftSchemas.cpp
+++ b/Drift/Private/DriftSchemas.cpp
@@ -21,6 +21,7 @@ bool FDriftEndpointsResponse::Serialize(SerializationContext& context)
 		&& SERIALIZE_PROPERTY(context, auth)
 		&& SERIALIZE_PROPERTY(context, clientlogs)
 		&& SERIALIZE_PROPERTY(context, clients)
+        && SERIALIZE_PROPERTY(context, client_configs)
 		&& SERIALIZE_PROPERTY(context, counters)
 		&& SERIALIZE_PROPERTY(context, eventlogs)
 		&& SERIALIZE_PROPERTY(context, flexmatch_regions)
@@ -143,6 +144,17 @@ bool FDriftPlayerUpdateResponse::Serialize(SerializationContext& context)
 bool FChangePlayerNamePayload::Serialize(SerializationContext& context)
 {
 	return SERIALIZE_PROPERTY(context, name);
+}
+
+bool FDriftClientConfigResponse::Serialize(SerializationContext& context)
+{
+    return SERIALIZE_PROPERTY(context, key)
+        && SERIALIZE_PROPERTY(context, value);
+}
+
+bool FDriftClientConfigListResponse::Serialize(SerializationContext& context)
+{
+    return SERIALIZE_PROPERTY(context, configs);
 }
 
 

--- a/Drift/Private/DriftSchemas.cpp
+++ b/Drift/Private/DriftSchemas.cpp
@@ -146,18 +146,6 @@ bool FChangePlayerNamePayload::Serialize(SerializationContext& context)
 	return SERIALIZE_PROPERTY(context, name);
 }
 
-bool FDriftClientConfigResponse::Serialize(SerializationContext& context)
-{
-    return SERIALIZE_PROPERTY(context, key)
-        && SERIALIZE_PROPERTY(context, value);
-}
-
-bool FDriftClientConfigListResponse::Serialize(SerializationContext& context)
-{
-    return SERIALIZE_PROPERTY(context, configs);
-}
-
-
 bool FCdnInfo::Serialize(SerializationContext& context)
 {
 	return SERIALIZE_PROPERTY(context, cdn)

--- a/Drift/Private/DriftSchemas.h
+++ b/Drift/Private/DriftSchemas.h
@@ -31,6 +31,7 @@ struct FDriftEndpointsResponse
 	FString auth;
 	FString clientlogs;
 	FString clients;
+    FString client_configs;
 	FString counters;
 	FString eventlogs;
 	FString flexmatch_regions;
@@ -215,6 +216,22 @@ struct FChangePlayerNamePayload
 };
 
 
+struct FDriftClientConfigResponse
+{
+    FString key;
+    FString value;
+
+    bool Serialize(SerializationContext& context);
+};
+
+struct FDriftClientConfigListResponse
+{
+    TArray<FDriftClientConfigResponse> configs;
+
+    bool Serialize(SerializationContext& context);
+};
+
+
 struct FCdnInfo
 {
 	FString cdn;
@@ -258,6 +275,7 @@ struct FServerRegistrationPayload
 
 	bool Serialize(class SerializationContext& context);
 };
+
 
 
 struct FMatchesPayload

--- a/Drift/Private/DriftSchemas.h
+++ b/Drift/Private/DriftSchemas.h
@@ -220,13 +220,13 @@ struct FChangePlayerNamePayload
 /*
  * Serialization of this from JSON to the struct, is handled by FJSonObjectConverter instead of JsonArchive
  */
-USTRUCT(BlueprintType)
+USTRUCT()
 struct FDriftClientConfigListResponse
 {
     GENERATED_BODY();
 
-    UPROPERTY(BlueprintReadOnly)
-    TMap<FString,FString> client_configs;
+    UPROPERTY()
+    TMap<FString, FString> client_configs;
 };
 
 

--- a/Drift/Private/DriftSchemas.h
+++ b/Drift/Private/DriftSchemas.h
@@ -16,6 +16,8 @@
 #include "JsonArchive.h"
 #include "Misc/DateTime.h"
 #include "DriftAPI.h"
+#include "CoreMinimal.h"
+#include "DriftSchemas.generated.h"
 
 
 class SerializationContext;
@@ -215,20 +217,16 @@ struct FChangePlayerNamePayload
 	bool Serialize(SerializationContext& context);
 };
 
-
-struct FDriftClientConfigResponse
-{
-    FString key;
-    FString value;
-
-    bool Serialize(SerializationContext& context);
-};
-
+/*
+ * Serialization of this from JSON to the struct, is handled by FJSonObjectConverter instead of JsonArchive
+ */
+USTRUCT(BlueprintType)
 struct FDriftClientConfigListResponse
 {
-    TArray<FDriftClientConfigResponse> configs;
+    GENERATED_BODY();
 
-    bool Serialize(SerializationContext& context);
+    UPROPERTY(BlueprintReadOnly)
+    TMap<FString,FString> client_configs;
 };
 
 

--- a/Drift/Public/DriftAPI.h
+++ b/Drift/Public/DriftAPI.h
@@ -944,6 +944,9 @@ public:
     */
     virtual void GetUserIdentitiesByName(const FString& name, const FDriftGetUserIdentitiesDelegate& delegate) = 0;
 
+    /* Gets the value of a client config from drift */
+    virtual FString GetDriftClientConfigValue(const FString& ConfigKey) = 0;
+
     /**
      * Flush all counters. Requires at least one tick to actually flush.
      * This is normally called automatically on a timer. Only use it when you want to prepare for shutdown,


### PR DESCRIPTION
This integrates the `client_configs` endpoint from drift-base into the client. 
The client configs are intended to be used to things like an arbitrary limit of party sizes for specific game modes without having to update the client.

Edit: Changed handling of the parsing of the response from `client_config`. This should now be able to handle the current response schema from the drift-base `client_config` endpoint. Therefore the changes on drift-base aren't required

Related PR: https://github.com/directivegames/perseus/pull/69