### PR TITLE
Add fetching client configs from drift-base on demand

### DIFF
--- a/Drift/Private/DriftBase.h
+++ b/Drift/Private/DriftBase.h
@@ -139,6 +139,7 @@ public:
     void FlushEvents() override;
 
     FString GetDriftClientConfigValue(const FString& ConfigKey) override;
+    void FetchDriftClientConfigs(const FDriftFetchClientConfigsComplete& InDelegate) override;
 
     void Shutdown() override;
 
@@ -221,7 +222,6 @@ public:
 
 private:
     void ConfigureSettingsSection(const FString& config);
-    void InitDriftClientConfigs();
 
     void GetRootEndpoints(TFunction<void()> onSuccess);
     void InitAuthentication(const FAuthenticationSettings& AuthenticationSettings);

--- a/Drift/Public/DriftAPI.h
+++ b/Drift/Public/DriftAPI.h
@@ -645,6 +645,8 @@ DECLARE_MULTICAST_DELEGATE_TwoParams(FDriftNewDeprecationDelegate, const FString
 
 DECLARE_MULTICAST_DELEGATE_OneParam(FDriftReceivedMessageDelegate, const FDriftMessage& /*Message*/);
 
+DECLARE_DELEGATE_OneParam(FDriftFetchClientConfigsComplete, bool /*bSuccess*/);
+
 
 struct FAuthenticationSettings
 {
@@ -944,8 +946,11 @@ public:
     */
     virtual void GetUserIdentitiesByName(const FString& name, const FDriftGetUserIdentitiesDelegate& delegate) = 0;
 
-    /* Gets the value of a client config from drift */
+    /* Gets the cached value of a client config from drift */
     virtual FString GetDriftClientConfigValue(const FString& ConfigKey) = 0;
+
+    /* Fetch client config values from the client and update the cache*/
+    virtual void FetchDriftClientConfigs(const FDriftFetchClientConfigsComplete& InDelegate) = 0;
 
     /**
      * Flush all counters. Requires at least one tick to actually flush.


### PR DESCRIPTION
This adds a new function to the DriftAPI to fetch the client configs from the backend on-demand instead of just fetching it when the game is launching and using that cached value always.